### PR TITLE
Fix off-by-one error which causes "M-SEARCH" to be missed if it's at the start of the UDP packet.

### DIFF
--- a/UpnpBroadcastResponder.cpp
+++ b/UpnpBroadcastResponder.cpp
@@ -67,7 +67,7 @@ void UpnpBroadcastResponder::serverLoop(){
   // check if this is a M-SEARCH for WeMo device
   String request = String((char *)packetBuffer);
 
-  if(request.indexOf('M-SEARCH') > 0) {
+  if(request.indexOf("M-SEARCH") >= 0) {
       // Issue https://github.com/kakopappa/arduino-esp8266-alexa-multiple-wemo-switch/issues/22 fix
       if((request.indexOf("urn:Belkin:device:**") > 0) || (request.indexOf("ssdp:all") > 0) || (request.indexOf("upnp:rootdevice") > 0)) {
         Serial.println("Got UDP Belkin Request..");


### PR DESCRIPTION
Also, change to use double quotes instead of single quotes so that "M-SEARCH" is a string rather than a character.